### PR TITLE
Added option to disable drawing under Dragon Sight

### DIFF
--- a/Avarice/Configuration/Profile.cs
+++ b/Avarice/Configuration/Profile.cs
@@ -115,6 +115,7 @@ public class Profile
     public float MnkDemolish = 6f;
     public bool MnkAoEDisable = false;
 
+    public bool DrgAnticipatedDisableRightEye = true;
 
     public DisplayCondition CompassCondition = DisplayCondition.Always;
     public ClassDisplayCondition CompassEnable = ClassDisplayCondition.Do_not_display;

--- a/Avarice/ConfigurationWindow/TabAnticipation.cs
+++ b/Avarice/ConfigurationWindow/TabAnticipation.cs
@@ -99,6 +99,15 @@ internal static unsafe class TabAnticipation
         }
     };
 
+    static InfoBox BoxDrg = new()
+    {
+        Label = "Job Specific: Dragoon",
+        ContentsAction = delegate
+        {
+            ImGui.Checkbox("Disable when under the effect of Right Eye", ref P.currentProfile.DrgAnticipatedDisableRightEye);
+        }
+    };
+
     internal static void Draw()
     {
         ImGuiHelpers.ScaledDummy(5f);
@@ -106,5 +115,6 @@ internal static unsafe class TabAnticipation
         BoxSam.DrawStretched();
         BoxNinja.DrawStretched();
         BoxMnk.DrawStretched();
+        BoxDrg.DrawStretched();
     }
 }

--- a/Avarice/Drawing/Canvas.cs
+++ b/Avarice/Drawing/Canvas.cs
@@ -1,6 +1,8 @@
 ﻿using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface.GameFonts;
+
+using ECommons;
 using ECommons.GameFunctions;
 using static Avarice.Drawing.DrawFunctions;
 using static Avarice.Drawing.Functions;
@@ -171,6 +173,7 @@ internal unsafe class Canvas : Window
 
         if (P.currentProfile.EnableAnticipatedPie.IsClassDisplayConditionMatching() && IsConditionMatching(P.currentProfile.AnticipatedPieSettings.DisplayCondition)
              && (!P.currentProfile.AnticipatedDisableTrueNorth || !Svc.ClientState.LocalPlayer.StatusList.Any(x => x.StatusId.EqualsAny(1250u)))
+             && (!P.currentProfile.DrgAnticipatedDisableRightEye || !Svc.ClientState.LocalPlayer.StatusList.Any(x => x.StatusId.EqualsAny(1910u)))
              && (!P.currentProfile.NinAnticipatedDisableMeikyoShisui || !Svc.ClientState.LocalPlayer.StatusList.Any(x => x.StatusId.EqualsAny(1233u))))
         {
             {


### PR DESCRIPTION
6.4 introduced a new effect for Dragon Sight where Right Eye acts as a 20 second long True North. Added a new box specifically for Dragoon to disable drawing the anticipated directional just like True North.