### PR TITLE
Reaper positional update and action data for IPC/RSR support

### DIFF
--- a/Avarice/StaticData/ActionID.cs
+++ b/Avarice/StaticData/ActionID.cs
@@ -2596,6 +2596,31 @@ public enum ActionID : uint
     /// 
     /// </summary>
     ArcaneCrest = 24404,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Sacrificium = 36969,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    ExecutionersGibbet = 36970,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    ExecutionersGallows = 36971,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    ExecutionersGuilotine = 36972,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Perfectio = 36973,
     #endregion
 
     #region SAM
@@ -3480,6 +3505,11 @@ public enum ActionID : uint
     /// 
     /// </summary>
     SwiftskinsCoil = 34622,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    Dreadwinter = 34620,
     #endregion
 
     #region General

--- a/Avarice/StaticData/Data.cs
+++ b/Avarice/StaticData/Data.cs
@@ -11,19 +11,27 @@ namespace Avarice.StaticData
     {
         public static readonly SortedList<ActionID, EnemyPositional> ActionPositional = new()
         {
+            //Dragoon
             {ActionID.FangandClaw, EnemyPositional.Flank},
             {ActionID.WheelingThrust, EnemyPositional.Rear},
             {ActionID.ChaosThrust, EnemyPositional.Rear },
             {ActionID.ChaoticSpring, EnemyPositional.Rear },
+            //Monk
             {ActionID.Demolish, EnemyPositional.Rear },
             {ActionID.SnapPunch, EnemyPositional.Flank },
+            //Ninja
             {ActionID.TrickAttack, EnemyPositional.Rear },
             {ActionID.AeolianEdge,EnemyPositional.Rear },
             {ActionID.ArmorCrush, EnemyPositional.Flank },
+            //Reaper
             {ActionID.Gibbet, EnemyPositional.Flank},
             {ActionID.Gallows, EnemyPositional.Rear },
+            {ActionID.ExecutionersGibbet, EnemyPositional.Flank},
+            {ActionID.ExecutionersGallows, EnemyPositional.Rear },
+            //Samurai
             {ActionID.Gekko, EnemyPositional.Rear},
             {ActionID.Kasha, EnemyPositional.Flank },
+            //Viper
             {ActionID.FlankstingStrike, EnemyPositional.Flank },
             {ActionID.FlanksbaneFang, EnemyPositional.Flank },
             {ActionID.HindstingStrike, EnemyPositional.Rear },

--- a/Avarice/Util.cs
+++ b/Avarice/Util.cs
@@ -198,9 +198,9 @@ internal static unsafe class Util
 
         var levelcheckHindsting = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34612).ClassJobLevel;
         var levelcheckHindsbane = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34613).ClassJobLevel;
-        var levelcheckSwiftskin = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34622).ClassJobLevel;
+        //var levelcheckSwiftskin = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34622).ClassJobLevel;
         var move = P.memory.LastComboMove;
-        return (levelcheckHindsting && move.EqualsAny(34609u)) || (levelcheckHindsbane && move.EqualsAny(34609u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3647u, 3648u)) || (levelcheckSwiftskin && move.EqualsAny(34620u, 34637u));
+        return (levelcheckHindsting && move.EqualsAny(34609u)) || (levelcheckHindsbane && move.EqualsAny(34609u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3647u, 3648u)); //|| (levelcheckSwiftskin && move.EqualsAny(34620u, 34637u));
     }
     public static bool IsViperAnticipatedFlank()
     {
@@ -215,9 +215,9 @@ internal static unsafe class Util
 
         var levelcheckFlanksting = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34610).ClassJobLevel;
         var levelcheckFlanksbane = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34611).ClassJobLevel;
-        var levelcheckHuntersCoil = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34621).ClassJobLevel;
+        //var levelcheckHuntersCoil = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34621).ClassJobLevel;
         var move = P.memory.LastComboMove;
-        return (levelcheckFlanksting && move.EqualsAny(34608u)) || (levelcheckFlanksbane && move.EqualsAny(34608u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3645u, 3646u)) || (levelcheckHuntersCoil && move.EqualsAny(34620u, 34636u));
+        return (levelcheckFlanksting && move.EqualsAny(34608u)) || (levelcheckFlanksbane && move.EqualsAny(34608u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3645u, 3646u)); //|| (levelcheckHuntersCoil && move.EqualsAny(34620u, 34636u));
     }
 
     public static bool IsDragoonAnticipatedRear()

--- a/Avarice/Util.cs
+++ b/Avarice/Util.cs
@@ -198,11 +198,10 @@ internal static unsafe class Util
 
         var levelcheckHindsting = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34612).ClassJobLevel;
         var levelcheckHindsbane = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34613).ClassJobLevel;
-        //var levelcheckSwiftskin = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34622).ClassJobLevel;
+        var levelcheckSwiftskin = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34622).ClassJobLevel;
         var move = P.memory.LastComboMove;
-        return (levelcheckHindsting && move.EqualsAny(34609u)) || (levelcheckHindsbane && move.EqualsAny(34609u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3647u, 3648u)); //|| (levelcheckSwiftskin && move.EqualsAny(34620u, 34637u));
+        return (levelcheckHindsting && move.EqualsAny(34609u)) || (levelcheckHindsbane && move.EqualsAny(34609u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3647u, 3648u)) || (levelcheckSwiftskin && move.EqualsAny(34620u, 34637u));
     }
-
     public static bool IsViperAnticipatedFlank()
     {
         //34608 = Hunters's Sting       (Lvl 30+)
@@ -216,9 +215,9 @@ internal static unsafe class Util
 
         var levelcheckFlanksting = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34610).ClassJobLevel;
         var levelcheckFlanksbane = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34611).ClassJobLevel;
-        //var levelcheckHuntersCoil = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34621).ClassJobLevel;
+        var levelcheckHuntersCoil = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(34621).ClassJobLevel;
         var move = P.memory.LastComboMove;
-        return (levelcheckFlanksting && move.EqualsAny(34608u)) || (levelcheckFlanksbane && move.EqualsAny(34608u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3645u, 3646u)); //|| (levelcheckHuntersCoil && move.EqualsAny(34620u, 34636u));
+        return (levelcheckFlanksting && move.EqualsAny(34608u)) || (levelcheckFlanksbane && move.EqualsAny(34608u)) || Player.Status.Any(x => x.StatusId.EqualsAny(3645u, 3646u)) || (levelcheckHuntersCoil && move.EqualsAny(34620u, 34636u));
     }
 
     public static bool IsDragoonAnticipatedRear()
@@ -265,24 +264,37 @@ internal static unsafe class Util
         return levelcheck && move.EqualsAny(7479u);
     }
 
+    // Notes on Reaper. Similar to Viper, Reaper has a double positional primer in Executioner and Soul Reaver.
+    // Avarice is currently unable to handle double positional anticipation, so for now, this is coded to treat Executioner and Soul Reaver as a single positional primer for Flank only.
+    // This means that if Executioner or Soul Reaver is active, Avarice will anticipate Flank positional first (picked over rear due to ease of use) then rotate between rear and flank based on statuses.
     public static bool IsReaperAnticipatedRear()
-    {       //2589 = Enhanced Gallows
+    {
+        //2589 = Enhanced Gallows
         //2587 = Soul Reaver - Able to use Gibbet, Gallows, and Guillotine.
         //2854 = Soul Reaver - Able to execute Guillotine.
-        //3858 = Executioner
-        //Idk why there are 2 soul reavers. The description is taken from garland tools
+        //3858 = Executioner - Able to execute Executioner's Gibbet, Executioner's Gallows, and Executioner's Guillotine.
 
-        return Player.Status.Any(x => x.StatusId.EqualsAny(2589u))
-            && Player.Status.Any(x => x.StatusId.EqualsAny(2587u, 2854u, 3858u));
+        //Enhanced Gallows, Soul Reaver, and Executioner are used to prime Exec/Gallows for rear positional
+        //24383 = Gallows
+        //36971 = Executioner's Gallows
+
+        var levelcheckGallows = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(24383).ClassJobLevel;
+        var levelcheckExecutionersGallows = Svc.ClientState.LocalPlayer.Level >= Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>().GetRow(36971).ClassJobLevel;
+        var move = P.memory.LastComboMove;
+        return (levelcheckGallows && move.EqualsAny(24382u)) || (levelcheckExecutionersGallows && move.EqualsAny(36970u)) || Player.Status.Any(x => x.StatusId.EqualsAny(2589u));
     }
     public static bool IsReaperAnticipatedFlank()
-    {   //2589 = Enhanced Gibbet
+    {
+        //2588 = Enhanced Gibbet
+        //2855 = EnhancedGibbet_2855
         //2587 = Soul Reaver - Able to use Gibbet, Gallows, and Guillotine.
         //2854 = Soul Reaver - Able to execute Guillotine.
-        //Idk why there are 2 soul reavers. The description is taken from garland tools
-        //3858 = Executioner
+        //3858 = Executioner - Able to execute Executioner's Gibbet, Executioner's Gallows, and Executioner's Guillotine.
 
-        return Player.Status.Any(x => x.StatusId.EqualsAny(2588u, 2855u))
-            && Player.Status.Any(x => x.StatusId.EqualsAny(2587u, 2854u, 3858u));
+        //Enhanced Gibbet, Soul Reaver, and Executioner are used to prime Exec/Gibbet for rear positional
+        //24382 = Gibbet
+        //36970 = Executioner's Gibbet
+
+        return Player.Status.Any(x => x.StatusId.EqualsAny(2588u, 2855u, 2587u, 2854u, 3858u));
     }
 }


### PR DESCRIPTION
Reaper rear positional anticipation moved off of just statuses and added level checks. Added Reaper action data to allow for IPC/RSR support of post-90 weaponskills.

Notes on Reaper complications added as well in Util

```
Notes on Reaper. Similar to Viper, Reaper has a double positional primer in Executioner and Soul Reaver.
Avarice is currently unable to handle double positional anticipation, so for now, this is coded to treat Executioner and Soul Reaver as a single positional primer for Flank only.
This means that if Executioner or Soul Reaver is active, Avarice will anticipate Flank positional first (picked over rear due to ease of use) then rotate between rear and flank based on statuses and lastcombomove.
```