### PR TITLE
OnlyDrawIfPositional bug

### DIFF
--- a/Avarice/LuminaSheets.cs
+++ b/Avarice/LuminaSheets.cs
@@ -51,6 +51,11 @@ namespace Avarice
 
         public static bool HasPositional(this IGameObject obj)
         {
+            // If the "Only show for positional targets" configuration is disabled,
+            // ignore BNpcBase filtering and treat all targets as positional.
+            if (!P.config.OnlyDrawIfPositional)
+                return true;
+
             if (obj is not IBattleNpc bnpc)
                 return false;
 

--- a/Avarice/LuminaSheets.cs
+++ b/Avarice/LuminaSheets.cs
@@ -5,125 +5,83 @@ using System.Linq;
 using ECommons.DalamudServices;
 using System.Reflection;
 
-namespace Avarice;
-
-internal static class LuminaSheets
+namespace Avarice
 {
-    // Cache of DataIDs for enemies that don't have positional requirements
-    internal static HashSet<uint> NonPositionalUnits = new();
-
-    // Cache of known positional requirement status for enemies
-    private static Dictionary<uint, bool> PositionalStatusCache = new();
-
-    // Status effect IDs that disable positional requirements
-    internal static readonly uint[] TrueNorthEffects = new uint[] { 1250 }; // True North status ID
-
-    internal static void Init()
+    internal static class LuminaSheets
     {
-        try
+        internal static HashSet<uint> NonPositionalUnits = new HashSet<uint>();
+        private static Dictionary<uint, bool> PositionalStatusCache = new Dictionary<uint, bool>();
+        internal static readonly uint[] TrueNorthEffects = new uint[] { 1250 };
+
+        internal static void Init()
         {
-            // Get the BNpcBase sheet
-            var bnpcSheet = Svc.Data.GetExcelSheet<BNpcBase>();
-            if (bnpcSheet != null)
+            try
             {
-                // Try to find the positional flag property
-                PropertyInfo property = typeof(BNpcBase).GetProperty("IsOmnidirectional");
-
-                if (property != null)
+                var bnpcSheet = Svc.Data.GetExcelSheet<BNpcBase>();
+                if (bnpcSheet != null)
                 {
-                    // Found the property, initialize using it
-                    foreach (var bnpc in bnpcSheet)
+                    PropertyInfo property = typeof(BNpcBase).GetProperty("IsOmnidirectional");
+                    if (property != null)
                     {
-                        if ((bool)property.GetValue(bnpc))
+                        foreach (var bnpc in bnpcSheet)
                         {
-                            NonPositionalUnits.Add(bnpc.RowId);
+                            if ((bool)property.GetValue(bnpc))
+                            {
+                                NonPositionalUnits.Add(bnpc.RowId);
+                            }
                         }
+                        Svc.Log.Debug($"Loaded {NonPositionalUnits.Count} non-positional enemy types from BNpcBase");
                     }
-
-                    Svc.Log.Debug($"Loaded {NonPositionalUnits.Count} non-positional enemy types from BNpcBase");
+                    else
+                    {
+                        Svc.Log.Debug("IsOmnidirectional property not found in BNpcBase");
+                    }
                 }
                 else
                 {
-                    Svc.Log.Debug("IsOmnidirectional property not found in BNpcBase, will use hitbox-based detection");
+                    Svc.Log.Error("Failed to load BNpcBase sheet");
                 }
             }
-            else
+            catch (System.Exception ex)
             {
-                Svc.Log.Error("Failed to load BNpcBase sheet");
+                Svc.Log.Error(ex, "Error initializing LuminaSheets");
+                NonPositionalUnits = new HashSet<uint>();
             }
         }
-        catch (System.Exception ex)
+
+        public static bool HasPositional(this IGameObject obj)
         {
-            Svc.Log.Error(ex, "Error initializing LuminaSheets");
-            NonPositionalUnits = new HashSet<uint>();
-        }
-    }
+            if (obj is not IBattleNpc bnpc)
+                return false;
 
-    // Extension method to check if an object has positional requirements
-    public static bool HasPositional(this IGameObject obj)
-    {
-        if (obj is not IBattleNpc bnpc)
-            return false;
+            uint dataId = bnpc.DataId;
+            if (PositionalStatusCache.TryGetValue(dataId, out bool hasPositional))
+                return hasPositional;
 
-        // Check cache first for performance
-        uint dataId = bnpc.DataId;
-        if (PositionalStatusCache.TryGetValue(dataId, out bool hasPositional))
-            return hasPositional;
-
-        // Primary check: Is this enemy in our non-positional list from BNpcBase?
-        bool result = !NonPositionalUnits.Contains(dataId);
-
-        // Secondary checks for special cases
-        if (result)
-        {
-            // Training dummies always have positionals regardless of database
-            if (IsTrainingDummy(bnpc))
-                result = true;
-            // Very large enemies typically don't have positionals
-            else if (bnpc.HitboxRadius > 10.0f)
+            bool result = !NonPositionalUnits.Contains(dataId);
+            if (result && bnpc.BattleNpcKind != Dalamud.Game.ClientState.Objects.Enums.BattleNpcSubKind.Enemy)
                 result = false;
-            // Only consider enemies that can be fought
-            else if (bnpc.BattleNpcKind != Dalamud.Game.ClientState.Objects.Enums.BattleNpcSubKind.Enemy)
-                result = false;
+
+            PositionalStatusCache[dataId] = result;
+            return result;
         }
 
-        // Cache the result
-        PositionalStatusCache[dataId] = result;
-
-        return result;
-    }
-
-    // Check if an object is a training dummy
-    public static bool IsTrainingDummy(IGameObject obj)
-    {
-        if (obj is not IBattleNpc bnpc)
-            return false;
-
-        // Common training dummy NameIDs
-        return bnpc.NameId == 674 ||  // Striking Dummy
-               bnpc.NameId == 675 ||  // Stone Striking Dummy
-               bnpc.NameId == 676 ||  // Wooden Striking Dummy
-               bnpc.NameId == 677;    // Popoto Striking Dummy
-    }
-
-    // Check if the player has True North or similar effect active
-    public static bool HasTrueNorthEffect()
-    {
-        if (Svc.ClientState.LocalPlayer == null)
-            return false;
-
-        foreach (var status in Svc.ClientState.LocalPlayer.StatusList)
+        public static bool HasTrueNorthEffect()
         {
-            if (TrueNorthEffects.Contains(status.StatusId))
-                return true;
+            if (Svc.ClientState.LocalPlayer == null)
+                return false;
+
+            foreach (var status in Svc.ClientState.LocalPlayer.StatusList)
+            {
+                if (TrueNorthEffects.Contains(status.StatusId))
+                    return true;
+            }
+            return false;
         }
 
-        return false;
-    }
-
-    // Clear caches (e.g., on zone change)
-    public static void ClearCaches()
-    {
-        PositionalStatusCache.Clear();
+        public static void ClearCaches()
+        {
+            PositionalStatusCache.Clear();
+        }
     }
 }


### PR DESCRIPTION
OnlyDrawIfPositional was being checked against the BNpcBase data from Lumina resulting in positional data still being checked while disabled. 